### PR TITLE
autoversion: Wrapper that selects Unicode version automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 language: go
 
 go:
-  - 1.8.x
-  - tip
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
+
+env:
+  GO111MODULE=on
 
 matrix:
   fast_finish: true
-  allow_failures:
-  - go: tip
 
 before_install:
   - go get -t -v ./...
 
 script:
   - go test -coverprofile=coverage.txt -covermode=atomic ./textseg
+  - cd autoversion && go test ./textseg
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/autoversion/go.mod
+++ b/autoversion/go.mod
@@ -1,0 +1,10 @@
+module github.com/apparentlymart/go-textseg/autoversion
+
+go 1.9
+
+require (
+	github.com/apparentlymart/go-textseg/v10 v10.0.0
+	github.com/apparentlymart/go-textseg/v11 v11.0.0
+	github.com/apparentlymart/go-textseg/v12 v12.0.0
+	github.com/apparentlymart/go-textseg/v9 v9.0.0
+)

--- a/autoversion/go.sum
+++ b/autoversion/go.sum
@@ -1,0 +1,9 @@
+github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
+github.com/apparentlymart/go-textseg/v10 v10.0.0 h1:r+LbXTC1M025le8hVaPcBK3wGP7OetgRNIA45tY3owY=
+github.com/apparentlymart/go-textseg/v10 v10.0.0/go.mod h1:F1tr+MjyFVyKL/bDyFnOPBLkU5Kjo5OJj1ZvVDO+q2w=
+github.com/apparentlymart/go-textseg/v11 v11.0.0 h1:uRr1tmgQxgE5F5vrTjt4kgQ890BeIiZCxTn4imQRfwA=
+github.com/apparentlymart/go-textseg/v11 v11.0.0/go.mod h1:/WgrmNsK+SJws9csFcq/B5VCHemxeHkKCUracylR6e8=
+github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbjdL7GzRt3F8NvfJ0=
+github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
+github.com/apparentlymart/go-textseg/v9 v9.0.0 h1:ABuoMoH9718xfw3xMNc9GZBRoIPSLFvl/BcnjjawxEk=
+github.com/apparentlymart/go-textseg/v9 v9.0.0/go.mod h1:dOFTZz5f+7hV9OmjfCrGyYddNS75I+nFirCeYbX+hGY=

--- a/autoversion/textseg/doc.go
+++ b/autoversion/textseg/doc.go
@@ -1,0 +1,26 @@
+// Package textseg is a wrapper around each of the the Unicode-version-specific
+// textseg implementations that selects an implementation automatically based
+// on the Unicode version of the Go standard library that it's being built
+// against.
+//
+// The main textseg modules are designed with one major version per Unicode
+// major version so that different callers in the same program can potentially
+// use the segmentation rules from different versions of Unicode. However, in
+// programs that are using textseg in conjunction with other Unicode-related
+// functionality in the Go standard library, it could be desirable to keep the
+// textseg version aligned with the Go library's Unicode version so that the
+// total behavior is consistent with a single Unicode version.
+//
+// The API of this package is a subset of the API of the underlying
+// version-specific packages, intended as a drop-in replacement for callers
+// who are using that subset.
+//
+// In order to avoid linking in the data for all unicode versions into a
+// program that imports the autoversion package, this package selects a Unicode
+// version based on the Go compiler version that the program is being built
+// with. That means that this package will need to be upgraded for each new
+// Go version that is released, even if it doesn't introduce a new version of
+// Unicode. There will be a compile-time error indicating that the
+// ScanGraphemeClusters function is unavailable if you are using a Go version
+// that is not supported by your current textseg autoversion package.
+package textseg

--- a/autoversion/textseg/unicode10.go
+++ b/autoversion/textseg/unicode10.go
@@ -1,0 +1,22 @@
+// +build go1.10,!go1.13
+
+package textseg
+
+import (
+	v10 "github.com/apparentlymart/go-textseg/v10/textseg"
+)
+
+// ScanGraphemeClusters is a split function for bufio.Scanner that splits on
+// grapheme cluster boundaries, using the text segmentation rules from the
+// Unicode version selected by the current Go runtime library.
+//
+// This function will appear to be missing if your current Go version is not
+// supported by your current version of this package.
+func ScanGraphemeClusters(data []byte, atEOF bool) (int, []byte, error) {
+	return v10.ScanGraphemeClusters(data, atEOF)
+}
+
+// UnicodeMajorVersion is the major version of Unicode being used by this
+// package. This should always match the first portion of the string returned
+// by unicode.Version in the Go standard library.
+const UnicodeMajorVersion = 10

--- a/autoversion/textseg/unicode11.go
+++ b/autoversion/textseg/unicode11.go
@@ -1,0 +1,22 @@
+// +build go1.13,!go1.14
+
+package textseg
+
+import (
+	v11 "github.com/apparentlymart/go-textseg/v11/textseg"
+)
+
+// ScanGraphemeClusters is a split function for bufio.Scanner that splits on
+// grapheme cluster boundaries, using the text segmentation rules from the
+// Unicode version selected by the current Go runtime library.
+//
+// This function will appear to be missing if your current Go version is not
+// supported by your current version of this package.
+func ScanGraphemeClusters(data []byte, atEOF bool) (int, []byte, error) {
+	return v11.ScanGraphemeClusters(data, atEOF)
+}
+
+// UnicodeMajorVersion is the major version of Unicode being used by this
+// package. This should always match the first portion of the string returned
+// by unicode.Version in the Go standard library.
+const UnicodeMajorVersion = 11

--- a/autoversion/textseg/unicode12.go
+++ b/autoversion/textseg/unicode12.go
@@ -1,0 +1,22 @@
+// +build go1.14,!go1.15
+
+package textseg
+
+import (
+	v12 "github.com/apparentlymart/go-textseg/v12/textseg"
+)
+
+// ScanGraphemeClusters is a split function for bufio.Scanner that splits on
+// grapheme cluster boundaries, using the text segmentation rules from the
+// Unicode version selected by the current Go runtime library.
+//
+// This function will appear to be missing if your current Go version is not
+// supported by your current version of this package.
+func ScanGraphemeClusters(data []byte, atEOF bool) (int, []byte, error) {
+	return v12.ScanGraphemeClusters(data, atEOF)
+}
+
+// UnicodeMajorVersion is the major version of Unicode being used by this
+// package. This should always match the first portion of the string returned
+// by unicode.Version in the Go standard library.
+const UnicodeMajorVersion = 12

--- a/autoversion/textseg/unicode9.go
+++ b/autoversion/textseg/unicode9.go
@@ -1,0 +1,22 @@
+// +build go1.7,!go1.10
+
+package textseg
+
+import (
+	v9 "github.com/apparentlymart/go-textseg/v9/textseg"
+)
+
+// ScanGraphemeClusters is a split function for bufio.Scanner that splits on
+// grapheme cluster boundaries, using the text segmentation rules from the
+// Unicode version selected by the current Go runtime library.
+//
+// This function will appear to be missing if your current Go version is not
+// supported by your current version of this package.
+func ScanGraphemeClusters(data []byte, atEOF bool) (int, []byte, error) {
+	return v9.ScanGraphemeClusters(data, atEOF)
+}
+
+// UnicodeMajorVersion is the major version of Unicode being used by this
+// package. This should always match the first portion of the string returned
+// by unicode.Version in the Go standard library.
+const UnicodeMajorVersion = 9

--- a/autoversion/textseg/version_agnostic.go
+++ b/autoversion/textseg/version_agnostic.go
@@ -1,0 +1,28 @@
+package textseg
+
+// The functions in this file are not currently specific to a given version of
+// go-textseg and so we just call into the version from the latest upstream
+// major version in all cases.
+
+import (
+	"bufio"
+
+	realImpl "github.com/apparentlymart/go-textseg/v12/textseg"
+)
+
+// ScanUTF8Sequences is a split function for bufio.Scanner that splits on UTF8 sequence boundaries.
+//
+// This is included largely for completeness, since this behavior is already built in to Go when ranging over a string.
+func ScanUTF8Sequences(data []byte, atEOF bool) (int, []byte, error) {
+	return realImpl.ScanUTF8Sequences(data, atEOF)
+}
+
+// TokenCount is a utility that uses a bufio.SplitFunc to count the number of recognized tokens in the given buffer.
+func TokenCount(buf []byte, splitFunc bufio.SplitFunc) (int, error) {
+	return realImpl.TokenCount(buf, splitFunc)
+}
+
+// AllTokens is a utility that uses a bufio.SplitFunc to produce a slice of all of the recognized tokens in the given buffer.
+func AllTokens(buf []byte, splitFunc bufio.SplitFunc) ([][]byte, error) {
+	return realImpl.AllTokens(buf, splitFunc)
+}

--- a/autoversion/textseg/version_specific_test.go
+++ b/autoversion/textseg/version_specific_test.go
@@ -1,0 +1,26 @@
+package textseg
+
+// Note that due to the nature of this package this will only test with the
+// go-textseg version that matches with the current Go runtime.
+
+import (
+	"testing"
+)
+
+func TestScanGraphemeClusters(t *testing.T) {
+	// Our goal here is only to test that we're really calling into an
+	// upstream ScanGraphemeClusters function and not, say, a different scanner
+	// function by mistake. It's not intended to be a deep test and should
+	// hopefully remain valid in future Unicode versions.
+	t.Logf("testing with implementation for Unicode major version %d", UnicodeMajorVersion)
+
+	const input = `whelp 🤦🏽‍♂️`
+	got, err := TokenCount([]byte(input), ScanGraphemeClusters)
+	want := 7
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got != want {
+		t.Errorf("wrong number of tokens\ninput: %s\ngot:   %d\nwant:  %d", input, got, want)
+	}
+}


### PR DESCRIPTION
The main functionality for this repository is Unicode-version-specific and we have a separate module import path for each so that callers can select the specific versions they need.

This new `autoversion` module is here to make life a little easier for callers who just want to match the text segmentation algorithm/data with the Unicode version being used in the Go standard library, so that Unicode support is consistent throughout the program.

It uses a compile-time switch based on the current Go version to select the appropriate `textseg` major version. It's based on Go version rather than Unicode version so that it can be a compile-time rather than a runtime decision, or else we'd end up with the tables for all Unicode versions linked into every program using this package.

Unfortunately this means that this package will need maintenance for each new version of Go that's released, but hopefully that small annoyance here leads to less annoyance for downstreams who can just upgrade this package to gain support for new Go/Unicode versions.

If a new version of Go is released then existing users of this module won't compile until they upgrade to a new version of the module that knows which Unicode version corresponds with that new Go version.
