### PR TITLE
Propagate version 13 to version_agnostic and to Go versions 1.17, 1.18, and 1.19

### DIFF
--- a/autoversion/textseg/unicode13.go
+++ b/autoversion/textseg/unicode13.go
@@ -1,4 +1,4 @@
-// +build go1.16,!go1.17
+// +build go1.16,go1.17,go1.18,go1.19,!go1.20
 
 package textseg
 

--- a/autoversion/textseg/version_agnostic.go
+++ b/autoversion/textseg/version_agnostic.go
@@ -7,7 +7,7 @@ package textseg
 import (
 	"bufio"
 
-	realImpl "github.com/apparentlymart/go-textseg/v12/textseg"
+	realImpl "github.com/apparentlymart/go-textseg/v13/textseg"
 )
 
 // ScanUTF8Sequences is a split function for bufio.Scanner that splits on UTF8 sequence boundaries.


### PR DESCRIPTION
Hi Martin,

I'm working on updating the Debian package, and building it would fail since `github.com/apparentlymart/go-textseg/v12/textseg` wouldn't be found. It makes sense as I'm packaging it as `github.com/apparentlymart/go-textseg/v13/textseg`.

I'm suggesting to move `version_agnostic` to the latest release accordingly.

Thanks for considering!

Cheers,
Cyril.